### PR TITLE
Javascript signalling

### DIFF
--- a/gstcefsrc.cc
+++ b/gstcefsrc.cc
@@ -326,17 +326,17 @@ class BrowserClient :
 {
   public:
 
-    BrowserClient(CefRefPtr<CefRenderHandler> rptr, CefRefPtr<CefAudioHandler> aptr, CefRefPtr<CefRequestHandler> rqptr, CefRefPtr<CefDisplayHandler> display_handler, GstCefSrc *element) :
-        render_handler(rptr),
-        audio_handler(aptr),
-        request_handler(rqptr),
-        display_handler(display_handler),
-        mElement(element)
+    BrowserClient(GstCefSrc *element) : mElement(element)
     {
+      this->render_handler = new RenderHandler(element);
+      this->audio_handler = new AudioHandler(element);
+      this->request_handler = new RequestHandler(element);
+      this->display_handler = new DisplayHandler(element);
     }
 
-    virtual CefRefPtr<CefLifeSpanHandler> GetLifeSpanHandler() override {
-        return this;
+    virtual CefRefPtr<CefLifeSpanHandler> GetLifeSpanHandler() override
+    {
+      return this;
     }
 
     virtual CefRefPtr<CefRenderHandler> GetRenderHandler() override
@@ -769,11 +769,7 @@ gst_cef_src_start(GstBaseSrc *base_src)
 {
   gboolean ret = FALSE;
   GstCefSrc *src = GST_CEF_SRC (base_src);
-  CefRefPtr<BrowserClient> browserClient;
-  CefRefPtr<RenderHandler> renderHandler = new RenderHandler(src);
-  CefRefPtr<AudioHandler> audioHandler = new AudioHandler(src);
-  CefRefPtr<RequestHandler> requestHandler = new RequestHandler(src);
-  CefRefPtr<DisplayHandler> displayHandler = new DisplayHandler(src);
+  CefRefPtr<BrowserClient> browserClient = new BrowserClient(src);
 
   /* Make sure CEF is initialized before posting a task */
   g_mutex_lock (&init_lock);
@@ -787,8 +783,6 @@ gst_cef_src_start(GstBaseSrc *base_src)
   GST_OBJECT_LOCK (src);
   src->n_frames = 0;
   GST_OBJECT_UNLOCK (src);
-
-  browserClient = new BrowserClient(renderHandler, audioHandler, requestHandler, displayHandler, src);
 #ifdef __APPLE__
   if (pthread_main_np()) {
     /* in the main thread as per Cocoa */

--- a/gstcefsrc.cc
+++ b/gstcefsrc.cc
@@ -414,17 +414,17 @@ void BrowserClient::MakeBrowser(int arg)
   g_mutex_unlock(&mElement->state_lock);
 }
 
-App::App(GstCefSrc *src) : src(src)
+BrowserApp::BrowserApp(GstCefSrc *src) : src(src)
 {
 }
 
-CefRefPtr<CefBrowserProcessHandler> App::GetBrowserProcessHandler()
+CefRefPtr<CefBrowserProcessHandler> BrowserApp::GetBrowserProcessHandler()
 {
   return this;
 }
 
 #ifdef __APPLE__
-void App::OnScheduleMessagePumpWork(int64_t delay_ms)
+void BrowserApp::OnScheduleMessagePumpWork(int64_t delay_ms)
 {
   static const int64_t kMaxTimerDelay = 1000.0 / 60.0;
 
@@ -453,7 +453,7 @@ void App::OnScheduleMessagePumpWork(int64_t delay_ms)
 }
 #endif
 
-void App::OnBeforeCommandLineProcessing(const CefString &process_type,
+void BrowserApp::OnBeforeCommandLineProcessing(const CefString &process_type,
                                              CefRefPtr<CefCommandLine> command_line)
 {
     command_line->AppendSwitchWithValue("autoplay-policy", "no-user-gesture-required");
@@ -566,7 +566,7 @@ run_cef (GstCefSrc *src)
 #endif
 
   CefSettings settings;
-  CefRefPtr<App> app;
+  CefRefPtr<BrowserApp> app;
   CefWindowInfo window_info;
   CefBrowserSettings browserSettings;
 
@@ -646,7 +646,7 @@ run_cef (GstCefSrc *src)
   g_free(base_path);
   g_free(locales_dir_path);
 
-  app = new App(src);
+  app = new BrowserApp(src);
 
   if (!CefInitialize(args, settings, app, nullptr)) {
     GST_ERROR ("Failed to initialize CEF");

--- a/gstcefsrc.cc
+++ b/gstcefsrc.cc
@@ -166,8 +166,8 @@ class RenderHandler : public CefRenderHandler
 {
   public:
 
-    RenderHandler(GstCefSrc *element) :
-        element (element)
+    RenderHandler(GstCefSrc *src) :
+        src (src)
     {
     }
 
@@ -177,32 +177,32 @@ class RenderHandler : public CefRenderHandler
 
     void GetViewRect(CefRefPtr<CefBrowser> browser, CefRect &rect) override
     {
-	  GST_LOG_OBJECT(element, "getting view rect");
-      GST_OBJECT_LOCK (element);
-      rect = CefRect(0, 0, element->vinfo.width ? element->vinfo.width : DEFAULT_WIDTH, element->vinfo.height ? element->vinfo.height : DEFAULT_HEIGHT);
-      GST_OBJECT_UNLOCK (element);
+	  GST_LOG_OBJECT(src, "getting view rect");
+      GST_OBJECT_LOCK (src);
+      rect = CefRect(0, 0, src->vinfo.width ? src->vinfo.width : DEFAULT_WIDTH, src->vinfo.height ? src->vinfo.height : DEFAULT_HEIGHT);
+      GST_OBJECT_UNLOCK (src);
     }
 
     void OnPaint(CefRefPtr<CefBrowser> browser, PaintElementType type, const RectList &dirtyRects, const void * buffer, int w, int h) override
     {
       GstBuffer *new_buffer;
 
-      GST_LOG_OBJECT (element, "painting, width / height: %d %d", w, h);
+      GST_LOG_OBJECT (src, "painting, width / height: %d %d", w, h);
 
-      new_buffer = gst_buffer_new_allocate (NULL, element->vinfo.width * element->vinfo.height * 4, NULL);
+      new_buffer = gst_buffer_new_allocate (NULL, src->vinfo.width * src->vinfo.height * 4, NULL);
       gst_buffer_fill (new_buffer, 0, buffer, w * h * 4);
 
-      GST_OBJECT_LOCK (element);
-      gst_buffer_replace (&(element->current_buffer), new_buffer);
+      GST_OBJECT_LOCK (src);
+      gst_buffer_replace (&(src->current_buffer), new_buffer);
       gst_buffer_unref (new_buffer);
-      GST_OBJECT_UNLOCK (element);
+      GST_OBJECT_UNLOCK (src);
 
-      GST_LOG_OBJECT (element, "done painting");
+      GST_LOG_OBJECT (src, "done painting");
     }
 
   private:
 
-    GstCefSrc *element;
+    GstCefSrc *src;
 
     IMPLEMENT_REFCOUNTING(RenderHandler);
 };
@@ -211,8 +211,8 @@ class AudioHandler : public CefAudioHandler
 {
   public:
 
-    AudioHandler(GstCefSrc *element) :
-        mElement (element)
+    AudioHandler(GstCefSrc *src) :
+        src (src)
     {
     }
 
@@ -233,9 +233,9 @@ class AudioHandler : public CefAudioHandler
     mRate = params.sample_rate;
     mChannels = channels;
 
-    GST_OBJECT_LOCK (mElement);
-    mElement->audio_events = g_list_append (mElement->audio_events, event);
-    GST_OBJECT_UNLOCK (mElement);
+    GST_OBJECT_LOCK (src);
+    src->audio_events = g_list_append (src->audio_events, event);
+    GST_OBJECT_UNLOCK (src);
   }
 
   void OnAudioStreamPacket(CefRefPtr<CefBrowser> browser,
@@ -247,7 +247,7 @@ class AudioHandler : public CefAudioHandler
     GstMapInfo info;
     gint i, j;
 
-    GST_LOG_OBJECT (mElement, "Handling audio stream packet with %d frames", frames);
+    GST_LOG_OBJECT (src, "Handling audio stream packet with %d frames", frames);
 
     buf = gst_buffer_new_allocate (NULL, mChannels * frames * 4, NULL);
 
@@ -261,18 +261,18 @@ class AudioHandler : public CefAudioHandler
     }
     gst_buffer_unmap (buf, &info);
 
-    GST_OBJECT_LOCK (mElement);
+    GST_OBJECT_LOCK (src);
 
     GST_BUFFER_DURATION (buf) = gst_util_uint64_scale (frames, GST_SECOND, mRate);
 
-    if (!mElement->audio_buffers) {
-      mElement->audio_buffers = gst_buffer_list_new();
+    if (!src->audio_buffers) {
+      src->audio_buffers = gst_buffer_list_new();
     }
 
-    gst_buffer_list_add (mElement->audio_buffers, buf);
-    GST_OBJECT_UNLOCK (mElement);
+    gst_buffer_list_add (src->audio_buffers, buf);
+    GST_OBJECT_UNLOCK (src);
 
-    GST_LOG_OBJECT (mElement, "Handled audio stream packet");
+    GST_LOG_OBJECT (src, "Handled audio stream packet");
   }
 
   void OnAudioStreamStopped(CefRefPtr<CefBrowser> browser) override
@@ -281,12 +281,12 @@ class AudioHandler : public CefAudioHandler
 
   void OnAudioStreamError(CefRefPtr<CefBrowser> browser,
                           const CefString& message) override {
-    GST_WARNING_OBJECT (mElement, "Audio stream error: %s", message.ToString().c_str());
+    GST_WARNING_OBJECT (src, "Audio stream error: %s", message.ToString().c_str());
   }
 
   private:
 
-    GstCefSrc *mElement;
+    GstCefSrc *src;
     gint mRate;
     gint mChannels;
     IMPLEMENT_REFCOUNTING(AudioHandler);
@@ -294,7 +294,7 @@ class AudioHandler : public CefAudioHandler
 
 class DisplayHandler : public CefDisplayHandler {
 public:
-  DisplayHandler(GstCefSrc *element) : mElement(element) {}
+  DisplayHandler(GstCefSrc *src) : src(src) {}
 
   ~DisplayHandler() = default;
 
@@ -319,13 +319,13 @@ public:
       gst_level = GST_LEVEL_NONE;
       break;
     };
-    GST_CAT_LEVEL_LOG (cef_console_debug, gst_level, mElement, "%s:%d %s", source.ToString().c_str(), line,
+    GST_CAT_LEVEL_LOG (cef_console_debug, gst_level, src, "%s:%d %s", source.ToString().c_str(), line,
       message.ToString().c_str());
     return false;
   }
 
 private:
-  GstCefSrc *mElement;
+  GstCefSrc *src;
   IMPLEMENT_REFCOUNTING(DisplayHandler);
 };
 
@@ -336,12 +336,12 @@ class BrowserClient :
 {
   public:
 
-    BrowserClient(GstCefSrc *element) : src(element)
+    BrowserClient(GstCefSrc *src) : src(src)
     {
 
-      this->render_handler = new RenderHandler(element);
-      this->audio_handler = new AudioHandler(element);
-      this->display_handler = new DisplayHandler(element);
+      this->render_handler = new RenderHandler(src);
+      this->audio_handler = new AudioHandler(src);
+      this->display_handler = new DisplayHandler(src);
     }
 
     // CefClient Methods:
@@ -422,7 +422,6 @@ class BrowserClient :
     }
 
     // CefRequestHandler methods:
-    // TODO - is the ResourceRequestHandler stuff required?
     bool OnBeforeBrowse(
       CefRefPtr<CefBrowser> browser,
       CefRefPtr<CefFrame> frame,
@@ -759,7 +758,7 @@ done:
 }
 
 static GstStateChangeReturn
-gst_cef_src_change_state(GstElement *element, GstStateChange transition)
+gst_cef_src_change_state(GstElement *src, GstStateChange transition)
 {
   GstStateChangeReturn result = GST_STATE_CHANGE_SUCCESS;
 
@@ -781,16 +780,16 @@ gst_cef_src_change_state(GstElement *element, GstStateChange transition)
       /* in the main thread as per Cocoa */
       if (pthread_main_np()) {
         g_mutex_unlock (&init_lock);
-        run_cef ((GstCefSrc*) element);
+        run_cef ((GstCefSrc*) src);
         g_mutex_lock (&init_lock);
       } else {
-        dispatch_async_f(dispatch_get_main_queue(), (GstCefSrc*)element, (dispatch_function_t)&run_cef);
+        dispatch_async_f(dispatch_get_main_queue(), (GstCefSrc*)src, (dispatch_function_t)&run_cef);
         while (cef_status == CEF_STATUS_INITIALIZING)
           g_cond_wait (&init_cond, &init_lock);
       }
 #else
         /* in a separate UI thread */
-      thread = g_thread_new("cef-ui-thread", (GThreadFunc) run_cef, (GstCefSrc*)element);
+      thread = g_thread_new("cef-ui-thread", (GThreadFunc) run_cef, (GstCefSrc*)src);
       while (cef_status == CEF_STATUS_INITIALIZING)
         g_cond_wait (&init_cond, &init_lock);
 #endif
@@ -822,7 +821,7 @@ gst_cef_src_change_state(GstElement *element, GstStateChange transition)
         gst_cef_shutdown (nullptr);
         g_mutex_lock (&init_lock);
       } else {
-        dispatch_async_f(dispatch_get_main_queue(), (GstCefSrc*)element, (dispatch_function_t)&gst_cef_shutdown);
+        dispatch_async_f(dispatch_get_main_queue(), (GstCefSrc*)src, (dispatch_function_t)&gst_cef_shutdown);
         while (cef_status == CEF_STATUS_SHUTTING_DOWN)
           g_cond_wait (&init_cond, &init_lock);
       }
@@ -843,7 +842,7 @@ gst_cef_src_change_state(GstElement *element, GstStateChange transition)
   }
 
   if (result == GST_STATE_CHANGE_FAILURE) return result;
-  result = GST_ELEMENT_CLASS(parent_class)->change_state(element, transition);
+  result = GST_ELEMENT_CLASS(parent_class)->change_state(src, transition);
 
   return result;
 }
@@ -1210,7 +1209,8 @@ gst_cef_src_class_init (GstCefSrcClass * klass)
 
   gst_element_class_set_static_metadata (gstelement_class,
       "Chromium Embedded Framework source", "Source/Video",
-      "Creates a video stream from an embedded Chromium browser", "Mathieu Duponchelle <mathieu@centricular.com>");
+      "Creates a video stream from an embedded Chromium browser",
+      "Mathieu Duponchelle <mathieu@centricular.com>");
 
   gst_element_class_add_static_pad_template (gstelement_class,
       &gst_cef_src_template);

--- a/gstcefsrc.cc
+++ b/gstcefsrc.cc
@@ -11,6 +11,7 @@
 #include <include/base/cef_bind.h>
 #include <include/base/cef_callback_helpers.h>
 #include <include/wrapper/cef_closure_task.h>
+#include <include/wrapper/cef_message_router.h>
 
 #include "gstcefsrc.h"
 #include "gstcefaudiometa.h"
@@ -126,6 +127,40 @@ gchar* get_plugin_base_path () {
   gst_object_unref(plugin);
   return base_path;
 }
+
+
+/** Cef Client */
+
+/** Handlers */
+
+// Handle messages in the browser process.
+class MessageHandler : public CefMessageRouterBrowserSide::Handler {
+ public:
+  explicit MessageHandler(const CefString& startup_url)
+      : startup_url_(startup_url) {}
+
+  // Called due to cefQuery execution in message_router.html.
+  bool OnQuery(CefRefPtr<CefBrowser> browser,
+               CefRefPtr<CefFrame> frame,
+               int64_t query_id,
+               const CefString& request,
+               bool persistent,
+               CefRefPtr<Callback> callback) override {
+    // Only handle messages from the startup URL.
+    const std::string& url = frame->GetURL();
+    if (url.find(startup_url_) != 0)
+      return false;
+
+    const std::string& message_name = request;
+    callback->Success(message_name + " is working");
+    return true;
+  }
+
+ private:
+  const CefString startup_url_;
+
+  DISALLOW_COPY_AND_ASSIGN(MessageHandler);
+};
 
 class RenderHandler : public CefRenderHandler
 {
@@ -301,7 +336,7 @@ class BrowserClient :
 {
   public:
 
-    BrowserClient(GstCefSrc *element) : mElement(element)
+    BrowserClient(GstCefSrc *element) : src(element)
     {
 
       this->render_handler = new RenderHandler(element);
@@ -309,6 +344,7 @@ class BrowserClient :
       this->display_handler = new DisplayHandler(element);
     }
 
+    // CefClient Methods:
     virtual CefRefPtr<CefLifeSpanHandler> GetLifeSpanHandler() override
     {
       return this;
@@ -334,20 +370,48 @@ class BrowserClient :
       return display_handler;
     }
 
-    virtual void OnRenderProcessTerminated(CefRefPtr<CefBrowser> browser, TerminationStatus status) override
+    bool OnProcessMessageReceived(
+      CefRefPtr<CefBrowser> browser,
+      CefRefPtr<CefFrame> frame,
+      CefProcessId source_process,
+      CefRefPtr<CefProcessMessage> message
+    ) override
     {
       CEF_REQUIRE_UI_THREAD();
-      GST_WARNING_OBJECT (mElement, "Render subprocess terminated, reloading URL!");
-      browser->Reload();
+
+      return browser_msg_router_->OnProcessMessageReceived(
+        browser,
+        frame,
+        source_process,
+        message
+      );
+    }
+
+    // CefLifeSpanHandler Methods:
+    void OnAfterCreated(CefRefPtr<CefBrowser> browser) override
+    {
+      CEF_REQUIRE_UI_THREAD();
+
+      if (!browser_msg_router_) {
+        // Create the browser-side router for query handling.
+        CefMessageRouterConfig config;
+        config.js_query_function = "gstSendMsg";
+        config.js_cancel_function = "gstCancelMsg";
+        browser_msg_router_ = CefMessageRouterBrowserSide::Create(config);
+
+        // Register handlers with the router.
+        browser_msg_handler_.reset(new MessageHandler(src->url));
+        browser_msg_router_->AddHandler(browser_msg_handler_.get(), false);
+      }
     }
 
     virtual void OnBeforeClose(CefRefPtr<CefBrowser> browser) override
     {
-      mElement->browser = nullptr;
-      g_mutex_lock (&mElement->state_lock);
-      mElement->started = FALSE;
-      g_cond_signal (&mElement->state_cond);
-      g_mutex_unlock(&mElement->state_lock);
+      src->browser = nullptr;
+      g_mutex_lock (&src->state_lock);
+      src->started = FALSE;
+      g_cond_signal (&src->state_cond);
+      g_mutex_unlock(&src->state_lock);
       g_mutex_lock(&init_lock);
       g_assert (browsers > 0);
       browsers -= 1;
@@ -357,6 +421,31 @@ class BrowserClient :
       g_mutex_unlock (&init_lock);
     }
 
+    // CefRequestHandler methods:
+    // TODO - is the ResourceRequestHandler stuff required?
+    bool OnBeforeBrowse(
+      CefRefPtr<CefBrowser> browser,
+      CefRefPtr<CefFrame> frame,
+      CefRefPtr<CefRequest> request,
+      bool user_gesture,
+      bool is_redirect
+    ) override
+    {
+      CEF_REQUIRE_UI_THREAD();
+
+      browser_msg_router_->OnBeforeBrowse(browser, frame);
+      return false;
+    }
+
+    virtual void OnRenderProcessTerminated(CefRefPtr<CefBrowser> browser, TerminationStatus status) override
+    {
+      CEF_REQUIRE_UI_THREAD();
+      GST_WARNING_OBJECT (src, "Render subprocess terminated, reloading URL!");
+      browser_msg_router_->OnRenderProcessTerminated(browser);
+      browser->Reload();
+    }
+
+    // Custom methods:
     void MakeBrowser(int)
     {
       CefWindowInfo window_info;
@@ -364,7 +453,14 @@ class BrowserClient :
       CefBrowserSettings browser_settings;
 
       window_info.SetAsWindowless(0);
-      browser = CefBrowserHost::CreateBrowserSync(window_info, this, std::string(mElement->url), browser_settings, nullptr, nullptr);
+      browser = CefBrowserHost::CreateBrowserSync(
+        window_info,
+        this,
+        std::string(src->url),
+        browser_settings,
+        nullptr,
+        nullptr
+      );
       g_mutex_lock (&init_lock);
       g_assert (browsers < G_MAXUINT64);
       browsers += 1;
@@ -372,26 +468,32 @@ class BrowserClient :
 
       browser->GetHost()->SetAudioMuted(true);
 
-      mElement->browser = browser;
+      src->browser = browser;
 
-      g_mutex_lock (&mElement->state_lock);
-      mElement->started = TRUE;
-      g_cond_signal (&mElement->state_cond);
-      g_mutex_unlock(&mElement->state_lock);
+      g_mutex_lock (&src->state_lock);
+      src->started = TRUE;
+      g_cond_signal (&src->state_cond);
+      g_mutex_unlock(&src->state_lock);
     }
 
   private:
+    // Handles the browser side of query routing.
+    CefRefPtr<CefMessageRouterBrowserSide> browser_msg_router_;
+    std::unique_ptr<CefMessageRouterBrowserSide::Handler> browser_msg_handler_;
 
     CefRefPtr<CefRenderHandler> render_handler;
     CefRefPtr<CefAudioHandler> audio_handler;
     CefRefPtr<CefDisplayHandler> display_handler;
 
   public:
-    GstCefSrc *mElement;
+    GstCefSrc *src;
 
     IMPLEMENT_REFCOUNTING(BrowserClient);
+    DISALLOW_COPY_AND_ASSIGN(BrowserClient);
 };
 
+
+/** Browser App methods */
 
 BrowserApp::BrowserApp(GstCefSrc *src) : src(src)
 {
@@ -479,6 +581,9 @@ void BrowserApp::OnBeforeCommandLineProcessing(const CefString &process_type,
       g_strfreev (flags_list);
     }
 }
+
+
+/** cefsrc (Gstreamer) methods */
 
 static GstFlowReturn gst_cef_src_create(GstPushSrc *push_src, GstBuffer **buf)
 {

--- a/gstcefsrc.h
+++ b/gstcefsrc.h
@@ -57,9 +57,9 @@ struct _GstCefSrcClass {
   GstPushSrcClass parent_class;
 };
 
-class App : public CefApp, public CefBrowserProcessHandler {
+class BrowserApp : public CefApp, public CefBrowserProcessHandler {
 public:
-  App(GstCefSrc *src);
+  BrowserApp(GstCefSrc *src);
 
   void OnBeforeCommandLineProcessing(const CefString &process_type,
                                      CefRefPtr<CefCommandLine> command_line) override;
@@ -69,7 +69,8 @@ public:
   void OnScheduleMessagePumpWork(int64_t delay_ms) override;
 #endif
 private:
-  IMPLEMENT_REFCOUNTING(App);
+  IMPLEMENT_REFCOUNTING(BrowserApp);
+  DISALLOW_COPY_AND_ASSIGN(BrowserApp);
   GstCefSrc *src;
 };
 

--- a/gstcefsrc.h
+++ b/gstcefsrc.h
@@ -44,6 +44,7 @@ struct _GstCefSrc {
   gchar *cef_cache_location;
   gboolean gpu;
   gboolean sandbox;
+  gboolean listen_for_js_signals;
   gint chromium_debug_port;
   CefRefPtr<CefBrowser> browser;
   CefRefPtr<CefApp> app;

--- a/gstcefsubprocess.cc
+++ b/gstcefsubprocess.cc
@@ -17,6 +17,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
+#include "include/wrapper/cef_message_router.h"
 #include <include/cef_app.h>
 #include <glib.h>
 
@@ -27,6 +28,98 @@
 #if !defined(__APPLE__) && defined(GST_CEF_USE_SANDBOX)
 #include "include/cef_sandbox_mac.h"
 #endif
+
+
+enum ProcessType {
+  PROCESS_TYPE_BROWSER,
+  PROCESS_TYPE_RENDERER,
+  PROCESS_TYPE_OTHER,
+};
+
+// These flags must match the Chromium values.
+const char kProcessType[] = "type";
+const char kRendererProcess[] = "renderer";
+#if defined(OS_LINUX)
+const char kZygoteProcess[] = "zygote";
+#endif
+
+CefRefPtr<CefCommandLine> CreateCommandLine(const CefMainArgs& main_args) {
+  CefRefPtr<CefCommandLine> command_line = CefCommandLine::CreateCommandLine();
+#if defined(OS_WIN)
+  command_line->InitFromString(::GetCommandLineW());
+#else
+  command_line->InitFromArgv(main_args.argc, main_args.argv);
+#endif
+  return command_line;
+}
+
+ProcessType GetProcessType(const CefMainArgs& main_args) {
+  // Create a temporary CommandLine object.
+  CefRefPtr<CefCommandLine> command_line = CreateCommandLine(main_args);
+  // The command-line flag won't be specified for the browser process.
+  if (!command_line->HasSwitch(kProcessType))
+    return PROCESS_TYPE_BROWSER;
+
+  const std::string& process_type = command_line->GetSwitchValue(kProcessType);
+  if (process_type == kRendererProcess)
+    return PROCESS_TYPE_RENDERER;
+
+#if defined(OS_LINUX)
+  // On Linux the zygote process is used to spawn other process types. Since we
+  // don't know what type of process it will be we give it the renderer app.
+  if (process_type == kZygoteProcess)
+    return PROCESS_TYPE_RENDERER;
+#endif
+
+  return PROCESS_TYPE_OTHER;
+}
+
+// Implementation of CefApp for the renderer process.
+class RendererApp : public CefApp, public CefRenderProcessHandler {
+ public:
+  RendererApp() {}
+
+  // CefApp methods:
+  CefRefPtr<CefRenderProcessHandler> GetRenderProcessHandler() override {
+    return this;
+  }
+
+  // CefRenderProcessHandler methods:
+  void OnWebKitInitialized() override {
+    // Create the renderer-side router for query handling.
+    CefMessageRouterConfig config;
+    config.js_query_function = "gstSendMsg";
+    config.js_cancel_function = "gstCancelMsg";
+    renderer_msg_router_ = CefMessageRouterRendererSide::Create(config);
+  }
+
+  void OnContextCreated(CefRefPtr<CefBrowser> browser,
+                        CefRefPtr<CefFrame> frame,
+                        CefRefPtr<CefV8Context> context) override {
+    renderer_msg_router_->OnContextCreated(browser, frame, context);
+  }
+
+  void OnContextReleased(CefRefPtr<CefBrowser> browser,
+                         CefRefPtr<CefFrame> frame,
+                         CefRefPtr<CefV8Context> context) override {
+    renderer_msg_router_->OnContextReleased(browser, frame, context);
+  }
+
+  bool OnProcessMessageReceived(CefRefPtr<CefBrowser> browser,
+                                CefRefPtr<CefFrame> frame,
+                                CefProcessId source_process,
+                                CefRefPtr<CefProcessMessage> message) override {
+    return renderer_msg_router_->OnProcessMessageReceived(
+      browser, frame, source_process, message);
+  }
+
+ private:
+  // Handles the renderer side of query routing.
+  CefRefPtr<CefMessageRouterRendererSide> renderer_msg_router_;
+
+  IMPLEMENT_REFCOUNTING(RendererApp);
+  DISALLOW_COPY_AND_ASSIGN(RendererApp);
+};
 
 int main(int argc, char * argv[])
 {
@@ -57,5 +150,19 @@ int main(int argc, char * argv[])
   }
 #endif
 
-  return CefExecuteProcess(args, nullptr, nullptr);
+  // NB: this function is executed on new thread per new CEF "process" / app
+  CefRefPtr<CefApp> app = nullptr;
+  switch (GetProcessType(args)) {
+    case PROCESS_TYPE_RENDERER:
+      app = new RendererApp();
+      break;
+    case PROCESS_TYPE_BROWSER:
+      // browser app created in main thread / executable
+      break;
+    case PROCESS_TYPE_OTHER:
+      // this is unused??
+      break;
+  }
+
+  return CefExecuteProcess(args, app, nullptr);
 }

--- a/html/ready_test.html
+++ b/html/ready_test.html
@@ -1,0 +1,90 @@
+<html>
+  <head>
+    <title>Signals Sample</title>
+    <script language="JavaScript">
+      const tStart = 3; // s
+      const tBad = 1; // s
+      const tDur = 5; // s
+      const dt = 0.1; // s
+      let time = 0;
+      let remTime = tStart + tDur;
+
+      function sendMessage(msg) {
+        // Send "command" to renderer process in CEF, which gets routed to
+        // the main thread
+        window.gstSendMsg({
+          request: msg,
+          onSuccess: function(response) {
+            try {
+              const json = JSON.parse(response);
+              showResult(json, false);
+              if (json && json.success && json.cmd === "ready") {
+                console.log("sending eos signal in 5s...");
+                setTimeout(() => {
+                  console.log("sending eos signal");
+                  sendMessage("eos");
+                }, tDur * 1000);
+              }
+            } catch (e) {
+              console.error("parse error", e);
+            }
+          },
+          onFailure: function(error_code, error_message) {
+            try {
+              const json = JSON.parse(error_message);
+              showResult(json, true);
+            } catch (e) {
+            console.error("parse error", e);
+            }
+          }
+        });
+      }
+
+      function showResult(resultJson, isError) {
+        document.getElementById("result").innerHTML +=
+          "<br />" + `${isError ? "error" : "response"} at ${time.toFixed(1)}s: ` + "<br />" +
+          JSON.stringify(resultJson, null, 4);
+      }
+
+      console.log("sending 'ready' signal in 3s...");
+      setTimeout(() => {
+        console.log("sending 'ready' signal");
+        sendMessage("ready");
+      }, tStart * 1000);
+
+      setTimeout(() => {
+        console.log("sending test 'bad' signal");
+        sendMessage("bad");
+      }, (tStart + tBad) * 1000);
+
+      setInterval(() => {
+        document.getElementById("timer").innerHTML =
+          `countdown: ${remTime.toFixed(1)}s` +  "<br />" +
+          `running: ${time.toFixed(1)}s`;
+
+        time += dt;
+        remTime -= dt;
+      }, dt * 1000);
+    </script>
+  </head>
+  <body
+    style="
+      overflow: hidden;
+      position: absolute;
+      width: 100%;
+      height: 100%;
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+      justify-content: center;
+      align-items: center;
+      background-color: white;
+    "
+  >
+    <div id="result" style="background-color: aqua; width: 30%; text-align: center;">
+      Responses:
+    </div>
+    <div id="timer" style="background-color: hotpink; width: 30%; text-align: center;"></div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
Based on [this sample](https://bitbucket.org/chromiumembedded/cef-project/src/master/examples/message_router), this adds a way to signal in javascript (from the webpage) a couple of things:
- "ready" - page is ready for rendering, so enable cefsrc to go to a PAUSED/PLAYING state
- "eos" - page doesn't have any more content, so push an EOS event onto cefsrc

This is useful for pages that have non-trivial load times and may run out of content (webgl pages, pages with videos, etc).

There is a sample in the html/ directory that shows how to send the signals, e.g.:
```
window.gstSendMsg({
          request: "ready",
          onSuccess: function(response) { ... }
          },
          onFailure: function(error_code, error_message) { ... }
        });
      }
```
To test, run a webserver in the html directory, say:
```
python -m http.server 9000
```
Then just specify the flag in a run pointing at that page:
```
gst-launch-1.0 -e cefsrc url="http://localhost:9000/ready_test.html" listen-for-js-signals=true ! video/x-raw, width=1920, height=1080, framerate=60/1 ! cefdemux name=d d.video ! queue max-size-bytes=0 max-size-buffers=0 max-size-time=3000000000 ! videoconvert ! xvimagesink
```